### PR TITLE
Add Windows time keeper WPF application

### DIFF
--- a/TimeKeeperApp/App.xaml
+++ b/TimeKeeperApp/App.xaml
@@ -1,0 +1,9 @@
+<Application x:Class="TimeKeeperApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:TimeKeeperApp"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+
+    </Application.Resources>
+</Application>

--- a/TimeKeeperApp/App.xaml.cs
+++ b/TimeKeeperApp/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace TimeKeeperApp;
+
+public partial class App : Application
+{
+}

--- a/TimeKeeperApp/MainWindow.xaml
+++ b/TimeKeeperApp/MainWindow.xaml
@@ -1,0 +1,65 @@
+<Window x:Class="TimeKeeperApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="W32 Time Keeper" Height="450" Width="700"
+        MinWidth="600" MinHeight="400">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBlock x:Name="StatusTextBlock"
+                   FontSize="16"
+                   FontWeight="SemiBold"
+                   TextWrapping="Wrap"
+                   Text="Ready" />
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,10,0,10" VerticalAlignment="Center">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <TextBlock Text="Drift allowance (ms):" VerticalAlignment="Center" />
+                <TextBox x:Name="DriftAllowanceTextBox" Width="80" Margin="5,0,0,0" />
+            </StackPanel>
+            <CheckBox x:Name="AutoStartCheckBox" Content="Auto start with Windows" VerticalAlignment="Center" Margin="20,0,0,0" />
+            <CheckBox x:Name="NotificationsCheckBox" Content="Notify on adjustment" VerticalAlignment="Center" Margin="10,0,0,0" />
+            <Button x:Name="SaveSettingsButton" Content="Save Settings" Width="120" Margin="10,0,0,0" Click="OnSaveSettings" />
+        </StackPanel>
+
+        <Grid Grid.Row="2" ColumnSpacing="15">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <GroupBox Header="Time Servers" Grid.Column="0">
+                <Grid Margin="5">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <ListBox x:Name="ServersListBox" />
+                    <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,5,0,0">
+                        <TextBox x:Name="NewServerTextBox" Width="200" ToolTip="Enter a hostname or IP address" />
+                        <Button Content="Add" Width="60" Margin="5,0,0,0" Click="OnAddServer" />
+                        <Button Content="Remove Selected" Width="120" Margin="5,0,0,0" Click="OnRemoveServer" />
+                    </StackPanel>
+                </Grid>
+            </GroupBox>
+            <GroupBox Header="Sync Controls" Grid.Column="1">
+                <StackPanel Margin="5">
+                    <Button Content="Sync Now" Click="OnSyncNow" Height="35" Margin="0,0,0,10" />
+                    <TextBlock TextWrapping="Wrap">
+                        The application checks the configured servers every five minutes and adjusts the system clock when the drift exceeds the configured allowance.
+                    </TextBlock>
+                    <TextBlock x:Name="LastSyncTextBlock" Text="Last sync: never" TextWrapping="Wrap" Margin="0,10,0,0" />
+                </StackPanel>
+            </GroupBox>
+        </Grid>
+
+        <StatusBar Grid.Row="3">
+            <StatusBarItem>
+                <TextBlock x:Name="TimerStatusTextBlock" Text="Monitoring stopped" />
+            </StatusBarItem>
+        </StatusBar>
+    </Grid>
+</Window>

--- a/TimeKeeperApp/MainWindow.xaml.cs
+++ b/TimeKeeperApp/MainWindow.xaml.cs
@@ -1,0 +1,205 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Forms;
+using TimeKeeperApp.Models;
+using TimeKeeperApp.Services;
+using MessageBox = System.Windows.MessageBox;
+
+namespace TimeKeeperApp;
+
+public partial class MainWindow : Window
+{
+    private readonly SettingsService _settingsService = new();
+    private readonly AutoStartService _autoStartService = new();
+    private readonly SystemTimeAdjuster _systemTimeAdjuster = new();
+    private readonly NotifyIcon _notifyIcon;
+    private ApplicationSettings _settings;
+    private readonly TimeSyncService _timeSyncService;
+    private bool _balloonShownOnce;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        _settings = _settingsService.Load();
+        _timeSyncService = new TimeSyncService(() => _settings, _systemTimeAdjuster);
+        _timeSyncService.SyncResult += OnSyncResult;
+
+        _notifyIcon = new NotifyIcon
+        {
+            Visible = false,
+            Icon = System.Drawing.SystemIcons.Application,
+            Text = "W32 Time Keeper"
+        };
+        _notifyIcon.DoubleClick += (_, _) => RestoreFromTray();
+
+        Loaded += OnLoaded;
+        Closing += OnClosing;
+        StateChanged += OnStateChanged;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        RefreshServerList();
+        DriftAllowanceTextBox.Text = _settings.DriftAllowanceMilliseconds.ToString();
+        NotificationsCheckBox.IsChecked = _settings.NotificationsEnabled;
+
+        try
+        {
+            AutoStartCheckBox.IsChecked = _autoStartService.IsEnabled();
+            _settings.AutoStartWithWindows = AutoStartCheckBox.IsChecked == true;
+        }
+        catch (Exception ex)
+        {
+            StatusTextBlock.Text = $"Unable to query auto-start setting: {ex.Message}";
+        }
+
+        TimerStatusTextBlock.Text = "Monitoring active";
+        _timeSyncService.Start();
+    }
+
+    private void RefreshServerList()
+    {
+        ServersListBox.ItemsSource = null;
+        ServersListBox.ItemsSource = _settings.TimeServers;
+    }
+
+    private async void OnSyncResult(object? sender, TimeSyncResultEventArgs e)
+    {
+        await Dispatcher.InvokeAsync(() =>
+        {
+            if (e.Success)
+            {
+                var drift = Math.Round(e.DriftMilliseconds, 2);
+                var serverDetails = string.IsNullOrWhiteSpace(e.Server) ? string.Empty : $" (server: {e.Server})";
+                LastSyncTextBlock.Text = $"Last sync: {DateTime.Now:G} | Drift: {drift} ms{serverDetails}";
+
+                if (e.TimeAdjusted && _settings.NotificationsEnabled)
+                {
+                    ShowNotification($"System time adjusted by {Math.Round(e.DriftMilliseconds)} ms.");
+                }
+            }
+            else
+            {
+                LastSyncTextBlock.Text = $"Last sync attempt: {DateTime.Now:G} | {e.Message}";
+                if (_settings.NotificationsEnabled)
+                {
+                    ShowNotification(e.Message, ToolTipIcon.Warning);
+                }
+            }
+
+            StatusTextBlock.Text = e.Message;
+        });
+    }
+
+    private void ShowNotification(string message, ToolTipIcon icon = ToolTipIcon.Info)
+    {
+        _notifyIcon.BalloonTipTitle = "W32 Time Keeper";
+        _notifyIcon.BalloonTipText = message;
+        _notifyIcon.BalloonTipIcon = icon;
+        _notifyIcon.Visible = true;
+        _notifyIcon.ShowBalloonTip(5000);
+    }
+
+    private void OnSaveSettings(object sender, RoutedEventArgs e)
+    {
+        if (!int.TryParse(DriftAllowanceTextBox.Text, out var drift) || drift < 0)
+        {
+            MessageBox.Show(this, "Please enter a valid non-negative number for drift allowance.", "Invalid value",
+                MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        _settings.DriftAllowanceMilliseconds = drift;
+        _settings.NotificationsEnabled = NotificationsCheckBox.IsChecked == true;
+
+        var requestedAutoStart = AutoStartCheckBox.IsChecked == true;
+        try
+        {
+            _autoStartService.SetEnabled(requestedAutoStart);
+            _settings.AutoStartWithWindows = requestedAutoStart;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Unable to update auto-start setting: {ex.Message}", "Auto-start",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+            AutoStartCheckBox.IsChecked = _settings.AutoStartWithWindows;
+        }
+
+        _settingsService.Save(_settings);
+        StatusTextBlock.Text = "Settings saved.";
+    }
+
+    private void OnAddServer(object sender, RoutedEventArgs e)
+    {
+        var newServer = NewServerTextBox.Text.Trim();
+        if (string.IsNullOrWhiteSpace(newServer))
+        {
+            return;
+        }
+
+        if (_settings.TimeServers.Any(s => string.Equals(s, newServer, StringComparison.OrdinalIgnoreCase)))
+        {
+            MessageBox.Show(this, "This server is already in the list.", "Duplicate", MessageBoxButton.OK,
+                MessageBoxImage.Information);
+            return;
+        }
+
+        _settings.TimeServers.Add(newServer);
+        RefreshServerList();
+        NewServerTextBox.Clear();
+        _settingsService.Save(_settings);
+    }
+
+    private void OnRemoveServer(object sender, RoutedEventArgs e)
+    {
+        if (ServersListBox.SelectedItem is not string server)
+        {
+            return;
+        }
+
+        _settings.TimeServers.Remove(server);
+        RefreshServerList();
+        _settingsService.Save(_settings);
+    }
+
+    private async void OnSyncNow(object sender, RoutedEventArgs e)
+    {
+        StatusTextBlock.Text = "Performing manual sync...";
+        await _timeSyncService.PerformSyncAsync();
+    }
+
+    private void OnStateChanged(object? sender, EventArgs e)
+    {
+        if (WindowState == WindowState.Minimized)
+        {
+            Hide();
+            _notifyIcon.Visible = true;
+            if (!_balloonShownOnce)
+            {
+                ShowNotification("Time Keeper continues to run in the background.");
+                _balloonShownOnce = true;
+            }
+        }
+        else if (WindowState == WindowState.Normal)
+        {
+            _notifyIcon.Visible = false;
+        }
+    }
+
+    private void RestoreFromTray()
+    {
+        Show();
+        WindowState = WindowState.Normal;
+        Activate();
+    }
+
+    private void OnClosing(object? sender, CancelEventArgs e)
+    {
+        _timeSyncService.Dispose();
+        _notifyIcon.Visible = false;
+        _notifyIcon.Dispose();
+    }
+}

--- a/TimeKeeperApp/Models/ApplicationSettings.cs
+++ b/TimeKeeperApp/Models/ApplicationSettings.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace TimeKeeperApp.Models;
+
+public class ApplicationSettings
+{
+    public List<string> TimeServers { get; set; } = new() { "pool.ntp.org", "time.google.com" };
+
+    public int DriftAllowanceMilliseconds { get; set; } = 1000;
+
+    public bool AutoStartWithWindows { get; set; }
+        = false;
+
+    public bool NotificationsEnabled { get; set; } = true;
+}

--- a/TimeKeeperApp/Services/AutoStartService.cs
+++ b/TimeKeeperApp/Services/AutoStartService.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Win32;
+
+namespace TimeKeeperApp.Services;
+
+public class AutoStartService
+{
+    private const string RunKeyPath = @"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+    private const string AppName = "W32TimeKeeper";
+
+    public bool IsEnabled()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: false);
+        var value = key?.GetValue(AppName) as string;
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    public void SetEnabled(bool enabled)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: true)
+            ?? throw new InvalidOperationException("Unable to open registry key for autorun.");
+
+        if (enabled)
+        {
+            var processPath = Process.GetCurrentProcess().MainModule?.FileName;
+            if (string.IsNullOrWhiteSpace(processPath))
+            {
+                throw new InvalidOperationException("Could not determine application path for auto-start registration.");
+            }
+
+            key.SetValue(AppName, $"\"{processPath}\"");
+        }
+        else
+        {
+            key.DeleteValue(AppName, throwOnMissingValue: false);
+        }
+    }
+}

--- a/TimeKeeperApp/Services/NtpClient.cs
+++ b/TimeKeeperApp/Services/NtpClient.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace TimeKeeperApp.Services;
+
+public static class NtpClient
+{
+    public static async Task<DateTime?> GetNetworkTimeAsync(string host, int timeoutMilliseconds = 3000)
+    {
+        return await Task.Run(() => QueryServer(host, timeoutMilliseconds));
+    }
+
+    private static DateTime? QueryServer(string host, int timeoutMilliseconds)
+    {
+        const int NtpPort = 123;
+        var ntpData = new byte[48];
+        ntpData[0] = 0x1B;
+
+        try
+        {
+            var addresses = Dns.GetHostAddresses(host);
+            var address = addresses.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork)
+                          ?? addresses.FirstOrDefault();
+            if (address == null)
+            {
+                return null;
+            }
+
+            using var socket = new Socket(address.AddressFamily, SocketType.Dgram, ProtocolType.Udp)
+            {
+                ReceiveTimeout = timeoutMilliseconds,
+                SendTimeout = timeoutMilliseconds
+            };
+
+            var ipEndPoint = new IPEndPoint(address, NtpPort);
+            socket.Connect(ipEndPoint);
+            socket.Send(ntpData);
+            var received = socket.Receive(ntpData);
+            if (received < 48)
+            {
+                return null;
+            }
+        }
+        catch
+        {
+            return null;
+        }
+
+        const byte serverReplyTime = 40;
+        ulong intPart = ((ulong)ntpData[serverReplyTime] << 24)
+            | ((ulong)ntpData[serverReplyTime + 1] << 16)
+            | ((ulong)ntpData[serverReplyTime + 2] << 8)
+            | ntpData[serverReplyTime + 3];
+
+        ulong fractPart = ((ulong)ntpData[serverReplyTime + 4] << 24)
+            | ((ulong)ntpData[serverReplyTime + 5] << 16)
+            | ((ulong)ntpData[serverReplyTime + 6] << 8)
+            | ntpData[serverReplyTime + 7];
+
+        var milliseconds = (intPart * 1000) + ((fractPart * 1000) / 0x100000000L);
+        var networkDateTime = new DateTime(1900, 1, 1).AddMilliseconds((long)milliseconds);
+        return networkDateTime.ToUniversalTime();
+    }
+}

--- a/TimeKeeperApp/Services/SettingsService.cs
+++ b/TimeKeeperApp/Services/SettingsService.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using TimeKeeperApp.Models;
+
+namespace TimeKeeperApp.Services;
+
+public class SettingsService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly string _settingsPath;
+
+    public SettingsService()
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var directory = Path.Combine(appData, "W32TimeKeeper");
+        Directory.CreateDirectory(directory);
+        _settingsPath = Path.Combine(directory, "settings.json");
+    }
+
+    public ApplicationSettings Load()
+    {
+        try
+        {
+            if (!File.Exists(_settingsPath))
+            {
+                return new ApplicationSettings();
+            }
+
+            var json = File.ReadAllText(_settingsPath);
+            var settings = JsonSerializer.Deserialize<ApplicationSettings>(json, JsonOptions);
+            return settings ?? new ApplicationSettings();
+        }
+        catch
+        {
+            return new ApplicationSettings();
+        }
+    }
+
+    public void Save(ApplicationSettings settings)
+    {
+        var json = JsonSerializer.Serialize(settings, JsonOptions);
+        File.WriteAllText(_settingsPath, json);
+    }
+}

--- a/TimeKeeperApp/Services/SystemTimeAdjuster.cs
+++ b/TimeKeeperApp/Services/SystemTimeAdjuster.cs
@@ -1,0 +1,49 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace TimeKeeperApp.Services;
+
+public class SystemTimeAdjuster
+{
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetSystemTime(ref SystemTime systemTime);
+
+    public bool TryApply(DateTime utcTime, out string? errorMessage)
+    {
+        var st = new SystemTime
+        {
+            Year = (ushort)utcTime.Year,
+            Month = (ushort)utcTime.Month,
+            DayOfWeek = (ushort)utcTime.DayOfWeek,
+            Day = (ushort)utcTime.Day,
+            Hour = (ushort)utcTime.Hour,
+            Minute = (ushort)utcTime.Minute,
+            Second = (ushort)utcTime.Second,
+            Milliseconds = (ushort)utcTime.Millisecond
+        };
+
+        if (!SetSystemTime(ref st))
+        {
+            var error = new Win32Exception(Marshal.GetLastWin32Error());
+            errorMessage = error.Message;
+            return false;
+        }
+
+        errorMessage = null;
+        return true;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SystemTime
+    {
+        public ushort Year;
+        public ushort Month;
+        public ushort DayOfWeek;
+        public ushort Day;
+        public ushort Hour;
+        public ushort Minute;
+        public ushort Second;
+        public ushort Milliseconds;
+    }
+}

--- a/TimeKeeperApp/Services/TimeSyncResultEventArgs.cs
+++ b/TimeKeeperApp/Services/TimeSyncResultEventArgs.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace TimeKeeperApp.Services;
+
+public class TimeSyncResultEventArgs : EventArgs
+{
+    private TimeSyncResultEventArgs(bool success, string message, double driftMilliseconds, bool adjusted, string? server)
+    {
+        Success = success;
+        Message = message;
+        DriftMilliseconds = driftMilliseconds;
+        TimeAdjusted = adjusted;
+        Server = server;
+    }
+
+    public bool Success { get; }
+
+    public string Message { get; }
+
+    public double DriftMilliseconds { get; }
+
+    public bool TimeAdjusted { get; }
+
+    public string? Server { get; }
+
+    public static TimeSyncResultEventArgs Success(double driftMilliseconds, bool adjusted, string? server)
+        => new(true, adjusted ? "System time adjusted." : "System time within drift allowance.", driftMilliseconds, adjusted, server);
+
+    public static TimeSyncResultEventArgs Fail(string message)
+        => new(false, message, 0, false, null);
+}

--- a/TimeKeeperApp/Services/TimeSyncService.cs
+++ b/TimeKeeperApp/Services/TimeSyncService.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TimeKeeperApp.Models;
+
+namespace TimeKeeperApp.Services;
+
+public class TimeSyncService : IDisposable
+{
+    private readonly Func<ApplicationSettings> _settingsProvider;
+    private readonly SystemTimeAdjuster _systemTimeAdjuster;
+    private readonly Timer _timer;
+    private readonly object _syncLock = new();
+    private bool _disposed;
+
+    public TimeSyncService(Func<ApplicationSettings> settingsProvider, SystemTimeAdjuster systemTimeAdjuster)
+    {
+        _settingsProvider = settingsProvider;
+        _systemTimeAdjuster = systemTimeAdjuster;
+        _timer = new Timer(OnTimerElapsed, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    public event EventHandler<TimeSyncResultEventArgs>? SyncResult;
+
+    public void Start()
+    {
+        _timer.Change(TimeSpan.Zero, TimeSpan.FromMinutes(5));
+    }
+
+    public void Stop()
+    {
+        _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    private void OnTimerElapsed(object? state)
+    {
+        _ = PerformSyncAsync();
+    }
+
+    public async Task PerformSyncAsync()
+    {
+        if (!Monitor.TryEnter(_syncLock))
+        {
+            return;
+        }
+
+        try
+        {
+            var settings = _settingsProvider();
+            if (settings.TimeServers == null || settings.TimeServers.Count == 0)
+            {
+                settings.TimeServers = new ApplicationSettings().TimeServers;
+            }
+
+            DateTime? networkTime = null;
+            string? serverUsed = null;
+
+            foreach (var server in settings.TimeServers.Where(s => !string.IsNullOrWhiteSpace(s)))
+            {
+                networkTime = await NtpClient.GetNetworkTimeAsync(server.Trim());
+                if (networkTime.HasValue)
+                {
+                    serverUsed = server;
+                    break;
+                }
+            }
+
+            if (!networkTime.HasValue)
+            {
+                SyncResult?.Invoke(this, TimeSyncResultEventArgs.Fail("Unable to reach any configured time server."));
+                return;
+            }
+
+            var currentUtc = DateTime.UtcNow;
+            var drift = (networkTime.Value - currentUtc).TotalMilliseconds;
+            var driftAbs = Math.Abs(drift);
+            var allowance = Math.Max(0, settings.DriftAllowanceMilliseconds);
+
+            if (driftAbs <= allowance)
+            {
+                SyncResult?.Invoke(this, TimeSyncResultEventArgs.Success(drift, false, serverUsed));
+                return;
+            }
+
+            var adjusted = _systemTimeAdjuster.TryApply(networkTime.Value, out var errorMessage);
+            if (adjusted)
+            {
+                SyncResult?.Invoke(this, TimeSyncResultEventArgs.Success(drift, true, serverUsed));
+            }
+            else
+            {
+                SyncResult?.Invoke(this, TimeSyncResultEventArgs.Fail($"Failed to adjust system time: {errorMessage}"));
+            }
+        }
+        catch (Exception ex)
+        {
+            SyncResult?.Invoke(this, TimeSyncResultEventArgs.Fail($"Unexpected error: {ex.Message}"));
+        }
+        finally
+        {
+            Monitor.Exit(_syncLock);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _timer.Dispose();
+        _disposed = true;
+    }
+}

--- a/TimeKeeperApp/TimeKeeperApp.csproj
+++ b/TimeKeeperApp/TimeKeeperApp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+</Project>

--- a/W32TimeKeeper.sln
+++ b/W32TimeKeeper.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TimeKeeperApp", "TimeKeeperApp\\TimeKeeperApp.csproj", "{A1F60F33-5BDA-47F5-9B0E-91B7F48C2C02}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {A1F60F33-5BDA-47F5-9B0E-91B7F48C2C02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {A1F60F33-5BDA-47F5-9B0E-91B7F48C2C02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {A1F60F33-5BDA-47F5-9B0E-91B7F48C2C02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {A1F60F33-5BDA-47F5-9B0E-91B7F48C2C02}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,25 @@
-TBC
+# W32 Time Keeper
+
+W32 Time Keeper is a Windows 11 desktop application that monitors the local system clock and keeps it aligned with user-configurable NTP servers. When the configured drift allowance is exceeded the application automatically corrects the clock and can optionally notify the user about the change.
+
+## Features
+
+- Monitor and synchronise the Windows system clock against a configurable list of time servers.
+- Set a drift allowance (in milliseconds) to control when the clock will be corrected.
+- Optional toast-style notifications whenever the system time is adjusted or a sync failure occurs.
+- Toggle automatic start-up with Windows (using the current user `Run` registry key).
+- Manual "Sync Now" option and continuous background synchronisation every five minutes.
+- Minimises to the system tray while continuing to operate.
+
+## Getting started
+
+1. Open the solution `W32TimeKeeper.sln` in Visual Studio 2022 (or newer) on Windows 11.
+2. Build the solution in the desired configuration (Debug or Release).
+3. Run the `TimeKeeperApp` project.
+
+> **Note**
+> Adjusting the system clock requires administrative privileges. Launch the application with elevated rights for the automatic adjustments to succeed.
+
+## Configuration files
+
+Application preferences (time servers, drift allowance, notification settings, auto-start preference) are stored in `%APPDATA%\\W32TimeKeeper\\settings.json` and are automatically created/updated by the app.


### PR DESCRIPTION
## Summary
- add a WPF desktop application that synchronises the system clock against user-configurable NTP servers and enforces a drift allowance
- implement settings persistence, auto-start toggling, tray minimisation, and balloon notifications for time adjustments or sync failures

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f29a2ea0208332b85f0a18c7edf5a8