### PR TITLE
Refine five-server monitoring validation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,45 @@
 # W32 Time Keeper
 
-W32 Time Keeper is a Windows desktop utility that monitors your system clock against a configurable list of network time servers and keeps it synchronized without relying on the built-in w32tm service. The application runs in the background, informs you when adjustments are made, and exposes a lightweight UI for manual syncs and configuration.
+W32 Time Keeper is a Windows desktop utility that monitors your system clock against a configurable list of network time servers and surfaces the live drift for each one. The application runs in the background, records offsets on a schedule you choose, and exposes a lightweight UI for managing servers and reviewing results.
 
 ## Features
 
-- **Background monitoring** – Periodically queries multiple NTP servers and adjusts the Windows system clock when drift exceeds your configured allowance.
-- **Manual sync** – Trigger an on-demand synchronization from the main window at any time.
-- **Start/Stop monitoring** – Use the toggle button to pause background checks or resume them as needed.
-- **Flexible server list** – Add or remove time servers directly from the UI; changes are persisted automatically.
-- **Tray integration** – Minimizes to the system tray with balloon notifications and restores on double-click.
-- **Configurable notifications** – Fine-tune notifications with separate controls for adjustment alerts and an overall mute.
-- **Windows auto-start** – Enable the app to launch automatically when Windows starts.
+- **Background monitoring** – Periodically queries up to five user-provided NTP servers and reports their offsets without blocking the UI.
+- **Five configurable servers** – The main window now exposes five labeled input slots where you can enter host names (e.g., `time.windows.com`). Empty secondary slots are ignored automatically.
+- **Configurable interval** – Choose how often the check cycle runs by setting the "Check interval (seconds)" field directly in the main view.
+- **Status dashboard** – See the most recent result for each server, including the timestamp, signed offset, and success/error state.
+- **Rolling log files** – Every result is appended to `logs/timechecks-YYYYMMDD.log` alongside the UI updates for later review.
 - **Per-user settings** – All preferences are saved to the current user profile and applied at startup.
 
 ## Configuration Options
 
-Open the **Settings** dialog to manage all configurable options:
+Use the main window to manage all configurable options:
 
-- **Drift allowance (ms):** Maximum drift tolerated before the clock is corrected.
-- **Check interval (s):** Frequency for background sync checks.
-- **Auto start with Windows:** Toggle to register/unregister the app as a startup program.
-- **Enable all notifications:** Master switch for tray notifications.
-- **Notify on time adjustment:** Optional alert shown only when the clock is adjusted.
-- **Time server list:** Manage servers from the main window using *Add* and *Remove Selected*.
+- **Server 1–5:** Enter host names (e.g., `time.windows.com`). Only populated entries are queried; Server 1 is required.
+- **Check interval (seconds):** Frequency for background checks. Values below 1 second are rejected.
+- **Start/Stop buttons:** Control whether the scheduler is running.
 
 ## How It Works
 
-1. On launch, the app loads saved settings, starts the background monitor, and populates the server list.
-2. A timer triggers periodic checks; each check queries your servers (first successful response wins).
-3. When a valid network time is retrieved, the app compares it to the local clock. If the drift exceeds your allowance, it attempts to adjust the system time.
-4. Results (success, error, server used) are shown in the UI and optionally as tray notifications.
-5. You can manually toggle monitoring, run one-off syncs, or update settings at any time. Changes take effect immediately and are stored for future sessions.
+1. On launch, the app loads saved settings (see below), starts the background monitor, and populates the five server slots.
+2. A timer triggers periodic checks; each cycle queries the populated servers sequentially (Server 1 → Server 5).
+3. The signed offset (server UTC minus system UTC) is calculated for each response and rounded to microseconds.
+4. Results (success or per-server error) are shown in the UI and written to the rolling log file.
+5. You can pause or resume monitoring with the buttons on the main window; updates take effect immediately and persist.
+
+## Configuration storage
+
+- **Settings file:** `%AppData%\W32TimeKeeper\settings.json`
+- **Log directory:** `logs\timechecks-YYYYMMDD.log` (relative to the application directory)
+
+The settings file stores the five server entries and the selected interval. It is updated automatically as fields change in the main window.
 
 ## Getting Started
 
 1. Build the solution with dotnet build (requires .NET 8.0 on Windows with WPF/WinForms support).
 2. Run the application (dotnet run or launch the generated executable).
-3. Configure your desired servers and thresholds via the **Settings** button.
-4. Leave the app running (minimized to tray) to keep your system clock aligned.
+3. Enter up to five time servers directly in the main window and set the desired interval.
+4. Leave the app running to monitor and log the offset for each configured server.
 
 ## Testing
 

--- a/TimeKeeperApp/MainWindow.xaml
+++ b/TimeKeeperApp/MainWindow.xaml
@@ -1,62 +1,159 @@
 <Window x:Class="TimeKeeperApp.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:TimeKeeperApp.ViewModels"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
         Title="W32 Time Keeper" Height="562" Width="754"
         MinWidth="600" MinHeight="400"
         ResizeMode="CanMinimize"
         Background="{DynamicResource WindowBackgroundBrush}"
-        Foreground="{DynamicResource WindowForegroundBrush}" Icon="/8f35f377-8ded-43fe-9a67-c68bbcde13f1.png">
+        Foreground="{DynamicResource WindowForegroundBrush}"
+        Icon="/8f35f377-8ded-43fe-9a67-c68bbcde13f1.png"
+        Loaded="OnLoaded"
+        Closing="OnClosing">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <Style x:Key="ValidationMessageStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="Foreground" Value="#CC1F1F" />
+            <Setter Property="Visibility" Value="Visible" />
+            <Style.Triggers>
+                <Trigger Property="Text" Value="">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                </Trigger>
+                <Trigger Property="Text" Value="{x:Null}">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                </Trigger>
+                <Trigger Property="Text" Value="{x:Static sys:String.Empty}">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
+    <Window.DataContext>
+        <vm:MainViewModel />
+    </Window.DataContext>
     <Grid Margin="10">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <TextBlock x:Name="StatusTextBlock"
-                   FontSize="16"
-                   FontWeight="SemiBold"
-                   TextWrapping="Wrap"
-                   Text="Ready" />
 
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,10,0,10" VerticalAlignment="Center"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="0" VerticalAlignment="Center">
+            <Button Content="Start Checks"
+                    Width="120"
+                    Height="32"
+                    Margin="0,0,10,0"
+                    Click="OnStartChecks"
+                    IsEnabled="{Binding CanStart}" />
+            <Button Content="Stop Checks"
+                    Width="120"
+                    Height="32"
+                    Margin="0,0,20,0"
+                    Click="OnStopChecks"
+                    IsEnabled="{Binding IsRunning}" />
+            <TextBlock Text="Interval:" VerticalAlignment="Center" />
+            <TextBlock Text="{Binding CheckIntervalSeconds}"
+                       Margin="4,0,0,0"
+                       FontWeight="SemiBold"
+                       VerticalAlignment="Center" />
+            <TextBlock Text="seconds"
+                       Margin="4,0,20,0"
+                       VerticalAlignment="Center" />
+            <TextBlock VerticalAlignment="Center">
+                <Run Text="Last overall check: " />
+                <Run Text="{Binding LastOverallCheckTime, StringFormat={}{0:G}, TargetNullValue=not yet}" />
+            </TextBlock>
+        </StackPanel>
 
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="1" ColumnSpacing="15">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <GroupBox Header="Time Servers" Grid.Column="0" Margin="0,0,15,0">
-                <Grid Margin="5">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-                    <ListBox x:Name="ServersListBox" />
-                    <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,5,0,0">
-                        <TextBox x:Name="NewServerTextBox" Width="200" ToolTip="Enter a hostname or IP address" />
-                        <Button Content="Add" Width="60" Margin="5,0,0,0" Click="OnAddServer" />
-                        <Button Content="Remove Selected" Width="120" Margin="5,0,0,0" Click="OnRemoveServer" />
+
+            <GroupBox Header="Server Configuration" Grid.Column="0">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="10">
+                        <ItemsControl ItemsSource="{Binding Servers}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Margin="0,0,0,12">
+                                        <TextBlock Text="{Binding Label}" FontWeight="SemiBold" />
+                                        <TextBox Text="{Binding Hostname, UpdateSourceTrigger=PropertyChanged}"
+                                                 Margin="0,4,0,0"
+                                                 ToolTip="Enter the server hostname"
+                                                 PreviewTextInput="OnServerPreviewTextInput"
+                                                 DataObject.Pasting="OnServerPaste"
+                                                 Tag="ServerInput" />
+                                        <TextBlock Text="{Binding Error}" Style="{StaticResource ValidationMessageStyle}" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <StackPanel Orientation="Horizontal" Margin="0,10,0,0" VerticalAlignment="Center">
+                            <TextBlock Text="Check interval (seconds)" VerticalAlignment="Center" />
+                            <TextBox Width="80"
+                                     Margin="10,0,0,0"
+                                     Text="{Binding CheckIntervalSeconds, UpdateSourceTrigger=PropertyChanged}"
+                                     PreviewTextInput="OnIntervalPreviewTextInput"
+                                     DataObject.Pasting="OnIntervalPaste"
+                                     HorizontalContentAlignment="Center" />
+                        </StackPanel>
+                        <TextBlock Text="{Binding IntervalError}" Style="{StaticResource ValidationMessageStyle}" Margin="0,4,0,0" />
                     </StackPanel>
-                </Grid>
+                </ScrollViewer>
             </GroupBox>
-            <GroupBox Header="Sync Controls" Grid.Column="1">
-                <StackPanel Margin="5">
-                    <Button x:Name="ToggleSyncButton" Content="Start Sync" Click="OnToggleSyncMonitoring" Height="35" Margin="0,0,0,10" FontWeight="Bold" />
-                    <Button Content="Sync Now" Click="OnSyncNow" Height="35" Margin="0,0,0,10" FontWeight="Bold" />
-                    <TextBlock TextWrapping="Wrap">
-                        The application checks the configured servers using your chosen interval and adjusts the system clock when the drift exceeds the configured allowance.
-                    </TextBlock>
-                    <TextBlock x:Name="LastSyncTextBlock" Text="Last sync: never" TextWrapping="Wrap" Margin="0,10,0,0" />
-                    <Button x:Name="OpenSettingsButton" Content="Settings" Click="OnOpenSettings" FontWeight="Bold" Height="35" Margin="0,10,0,0" />
-                </StackPanel>
+
+            <GroupBox Header="Server Status" Grid.Column="1">
+                <ListView ItemsSource="{Binding ServerStatuses}" Margin="10">
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn Header="Server" Width="160" DisplayMemberBinding="{Binding Server}" />
+                            <GridViewColumn Header="Last Checked" Width="140">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding LastChecked, StringFormat={}{0:G}, TargetNullValue=—}" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn Header="Offset (s)" Width="100">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding OffsetSeconds, StringFormat={}{0:+0.000000;-0.000000;+0.000000}, TargetNullValue=—}"
+                                                   HorizontalAlignment="Right" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn Header="Status" Width="200">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding StatusMessage}" TextWrapping="Wrap">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Foreground" Value="{DynamicResource WindowForegroundBrush}" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding HasError}" Value="True">
+                                                            <Setter Property="Foreground" Value="#CC1F1F" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
             </GroupBox>
         </Grid>
 
-        <StatusBar Grid.Row="3">
-            <StatusBarItem>
-                <TextBlock x:Name="TimerStatusTextBlock" Text="Monitoring stopped" />
-            </StatusBarItem>
-        </StatusBar>
+        <StackPanel Grid.Row="2" Margin="0,10,0,0">
+            <TextBlock Text="{Binding GlobalStatusMessage}" FontWeight="SemiBold" TextWrapping="Wrap" />
+            <TextBlock Text="{Binding GlobalWarningMessage}" Foreground="#CC1F1F" TextWrapping="Wrap" Visibility="{Binding HasGlobalWarning, Converter={StaticResource BoolToVisibilityConverter}}" />
+        </StackPanel>
     </Grid>
 </Window>

--- a/TimeKeeperApp/Models/ServerEntry.cs
+++ b/TimeKeeperApp/Models/ServerEntry.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace TimeKeeperApp.Models;
+
+public class ServerEntry : INotifyPropertyChanged
+{
+    private string _hostname = string.Empty;
+    private string? _error;
+
+    public ServerEntry(int index)
+    {
+        Index = index;
+        Label = $"Server {index + 1}";
+    }
+
+    public int Index { get; }
+
+    public string Label { get; }
+
+    public string Hostname
+    {
+        get => _hostname;
+        set
+        {
+            var trimmed = (value ?? string.Empty).Trim();
+            if (_hostname == trimmed)
+            {
+                return;
+            }
+
+            _hostname = trimmed;
+            OnPropertyChanged();
+        }
+    }
+
+    public string? Error
+    {
+        get => _error;
+        set
+        {
+            if (_error == value)
+            {
+                return;
+            }
+
+            _error = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/TimeKeeperApp/Models/ServerStatus.cs
+++ b/TimeKeeperApp/Models/ServerStatus.cs
@@ -1,0 +1,112 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace TimeKeeperApp.Models;
+
+public class ServerStatus : INotifyPropertyChanged
+{
+    private string _server = string.Empty;
+    private DateTime? _lastChecked;
+    private double? _offsetSeconds;
+    private string _statusMessage = "Not checked";
+    private bool _hasError;
+    private int _slotIndex;
+
+    public string Server
+    {
+        get => _server;
+        set
+        {
+            if (_server == value)
+            {
+                return;
+            }
+
+            _server = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public int SlotIndex
+    {
+        get => _slotIndex;
+        set
+        {
+            if (_slotIndex == value)
+            {
+                return;
+            }
+
+            _slotIndex = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public DateTime? LastChecked
+    {
+        get => _lastChecked;
+        set
+        {
+            if (_lastChecked == value)
+            {
+                return;
+            }
+
+            _lastChecked = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public double? OffsetSeconds
+    {
+        get => _offsetSeconds;
+        set
+        {
+            if (_offsetSeconds == value)
+            {
+                return;
+            }
+
+            _offsetSeconds = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        set
+        {
+            if (_statusMessage == value)
+            {
+                return;
+            }
+
+            _statusMessage = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool HasError
+    {
+        get => _hasError;
+        set
+        {
+            if (_hasError == value)
+            {
+                return;
+            }
+
+            _hasError = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/TimeKeeperApp/Models/TimeCheckSettings.cs
+++ b/TimeKeeperApp/Models/TimeCheckSettings.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace TimeKeeperApp.Models;
+
+public class TimeCheckSettings
+{
+    public List<string> Servers { get; set; } = new() { "time.windows.com", "pool.ntp.org", string.Empty, string.Empty, string.Empty };
+
+    public int IntervalSeconds { get; set; } = 60;
+}

--- a/TimeKeeperApp/Properties/AssemblyInfo.cs
+++ b/TimeKeeperApp/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("TimeKeeperApp.Tests")]

--- a/TimeKeeperApp/Services/INtpClient.cs
+++ b/TimeKeeperApp/Services/INtpClient.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TimeKeeperApp.Services;
+
+public interface INtpClient
+{
+    Task<NtpQueryResult> QueryAsync(string host, int timeoutMilliseconds, CancellationToken cancellationToken);
+}

--- a/TimeKeeperApp/Services/ISettingsStore.cs
+++ b/TimeKeeperApp/Services/ISettingsStore.cs
@@ -1,0 +1,10 @@
+using TimeKeeperApp.Models;
+
+namespace TimeKeeperApp.Services;
+
+public interface ISettingsStore
+{
+    TimeCheckSettings Load();
+
+    void Save(TimeCheckSettings settings);
+}

--- a/TimeKeeperApp/Services/ISystemClock.cs
+++ b/TimeKeeperApp/Services/ISystemClock.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace TimeKeeperApp.Services;
+
+public interface ISystemClock
+{
+    DateTime UtcNow { get; }
+    DateTime Now { get; }
+}

--- a/TimeKeeperApp/Services/ITimeCheckLogger.cs
+++ b/TimeKeeperApp/Services/ITimeCheckLogger.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TimeKeeperApp.Services;
+
+public interface ITimeCheckLogger
+{
+    Task LogAsync(DateTime timestamp, string server, double? offsetSeconds, string status, CancellationToken cancellationToken);
+}

--- a/TimeKeeperApp/Services/NtpClient.cs
+++ b/TimeKeeperApp/Services/NtpClient.cs
@@ -2,66 +2,99 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace TimeKeeperApp.Services;
 
-public static class NtpClient
+public class NtpClient : INtpClient
 {
-    public static async Task<DateTime?> GetNetworkTimeAsync(string host, int timeoutMilliseconds = 3000)
-    {
-        return await Task.Run(() => QueryServer(host, timeoutMilliseconds));
-    }
+    private const int NtpPort = 123;
+    private const int NtpPacketLength = 48;
+    private const byte TransmitTimestampOffset = 40;
 
-    private static DateTime? QueryServer(string host, int timeoutMilliseconds)
+    public async Task<NtpQueryResult> QueryAsync(string host, int timeoutMilliseconds, CancellationToken cancellationToken)
     {
-        const int NtpPort = 123;
-        var ntpData = new byte[48];
-        ntpData[0] = 0x1B;
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            throw new NtpClientException("Host name is required.");
+        }
 
         try
         {
-            var addresses = Dns.GetHostAddresses(host);
-            var address = addresses.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork)
-                          ?? addresses.FirstOrDefault();
-            if (address == null)
-            {
-                return null;
-            }
-
-            using var socket = new Socket(address.AddressFamily, SocketType.Dgram, ProtocolType.Udp)
-            {
-                ReceiveTimeout = timeoutMilliseconds,
-                SendTimeout = timeoutMilliseconds
-            };
-
-            var ipEndPoint = new IPEndPoint(address, NtpPort);
-            socket.Connect(ipEndPoint);
-            socket.Send(ntpData);
-            var received = socket.Receive(ntpData);
-            if (received < 48)
-            {
-                return null;
-            }
+            return await Task.Run(() => QueryInternal(host.Trim(), timeoutMilliseconds, cancellationToken), cancellationToken)
+                .ConfigureAwait(false);
         }
-        catch
+        catch (OperationCanceledException)
         {
-            return null;
+            throw;
+        }
+        catch (SocketException ex)
+        {
+            throw new NtpClientException($"Socket error contacting '{host}': {ex.Message}", ex);
+        }
+        catch (Exception ex) when (ex is not NtpClientException)
+        {
+            throw new NtpClientException($"Unable to query '{host}': {ex.Message}", ex);
+        }
+    }
+
+    private static NtpQueryResult QueryInternal(string host, int timeoutMilliseconds, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var ntpData = new byte[NtpPacketLength];
+        ntpData[0] = 0x1B;
+
+        var addresses = Dns.GetHostAddresses(host);
+        var address = addresses.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork)
+                      ?? addresses.FirstOrDefault();
+        if (address is null)
+        {
+            throw new NtpClientException($"No IP addresses resolved for '{host}'.");
         }
 
-        const byte serverReplyTime = 40;
-        ulong intPart = ((ulong)ntpData[serverReplyTime] << 24)
-            | ((ulong)ntpData[serverReplyTime + 1] << 16)
-            | ((ulong)ntpData[serverReplyTime + 2] << 8)
-            | ntpData[serverReplyTime + 3];
+        using var socket = new Socket(address.AddressFamily, SocketType.Dgram, ProtocolType.Udp)
+        {
+            ReceiveTimeout = timeoutMilliseconds,
+            SendTimeout = timeoutMilliseconds
+        };
 
-        ulong fractPart = ((ulong)ntpData[serverReplyTime + 4] << 24)
-            | ((ulong)ntpData[serverReplyTime + 5] << 16)
-            | ((ulong)ntpData[serverReplyTime + 6] << 8)
-            | ntpData[serverReplyTime + 7];
+        var endPoint = new IPEndPoint(address, NtpPort);
+        socket.Connect(endPoint);
 
-        var milliseconds = (intPart * 1000) + ((fractPart * 1000) / 0x100000000L);
-        var networkDateTime = new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds((long)milliseconds);
+        cancellationToken.ThrowIfCancellationRequested();
+        socket.Send(ntpData);
+
+        var received = socket.Receive(ntpData);
+        if (received < NtpPacketLength)
+        {
+            throw new NtpClientException("Incomplete NTP response received.");
+        }
+
+        var serverTime = ExtractNetworkTime(ntpData);
+        return new NtpQueryResult(serverTime);
+    }
+
+    internal static DateTime ExtractNetworkTime(byte[] ntpData)
+    {
+        if (ntpData.Length < NtpPacketLength)
+        {
+            throw new ArgumentException("Invalid NTP response length.", nameof(ntpData));
+        }
+
+        var intPart = ((ulong)ntpData[TransmitTimestampOffset] << 24)
+                      | ((ulong)ntpData[TransmitTimestampOffset + 1] << 16)
+                      | ((ulong)ntpData[TransmitTimestampOffset + 2] << 8)
+                      | ntpData[TransmitTimestampOffset + 3];
+
+        var fractPart = ((ulong)ntpData[TransmitTimestampOffset + 4] << 24)
+                        | ((ulong)ntpData[TransmitTimestampOffset + 5] << 16)
+                        | ((ulong)ntpData[TransmitTimestampOffset + 6] << 8)
+                        | ntpData[TransmitTimestampOffset + 7];
+
+        var milliseconds = (intPart * 1000d) + ((fractPart * 1000d) / 0x100000000L);
+        var networkDateTime = new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(milliseconds);
         return networkDateTime;
     }
 }

--- a/TimeKeeperApp/Services/NtpClientException.cs
+++ b/TimeKeeperApp/Services/NtpClientException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace TimeKeeperApp.Services;
+
+public class NtpClientException : Exception
+{
+    public NtpClientException(string message) : base(message)
+    {
+    }
+
+    public NtpClientException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/TimeKeeperApp/Services/NtpQueryResult.cs
+++ b/TimeKeeperApp/Services/NtpQueryResult.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TimeKeeperApp.Services;
+
+public class NtpQueryResult
+{
+    public NtpQueryResult(DateTime serverTimeUtc)
+    {
+        ServerTimeUtc = serverTimeUtc;
+    }
+
+    public DateTime ServerTimeUtc { get; }
+}

--- a/TimeKeeperApp/Services/SettingsStore.cs
+++ b/TimeKeeperApp/Services/SettingsStore.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using TimeKeeperApp.Models;
+
+namespace TimeKeeperApp.Services;
+
+public class SettingsStore : ISettingsStore
+{
+    private const string AppFolderName = "W32TimeKeeper";
+    private const string SettingsFileName = "settings.json";
+
+    public TimeCheckSettings Load()
+    {
+        try
+        {
+            var path = GetSettingsPath();
+            if (!File.Exists(path))
+            {
+                return new TimeCheckSettings();
+            }
+
+            var json = File.ReadAllText(path);
+            var settings = JsonSerializer.Deserialize<TimeCheckSettings>(json);
+            return settings ?? new TimeCheckSettings();
+        }
+        catch
+        {
+            return new TimeCheckSettings();
+        }
+    }
+
+    public void Save(TimeCheckSettings settings)
+    {
+        var directory = GetSettingsDirectory();
+        Directory.CreateDirectory(directory);
+        var path = GetSettingsPath();
+
+        var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+
+        File.WriteAllText(path, json);
+    }
+
+    private static string GetSettingsDirectory()
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        return Path.Combine(appData, AppFolderName);
+    }
+
+    private static string GetSettingsPath()
+    {
+        return Path.Combine(GetSettingsDirectory(), SettingsFileName);
+    }
+}

--- a/TimeKeeperApp/Services/SystemClock.cs
+++ b/TimeKeeperApp/Services/SystemClock.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace TimeKeeperApp.Services;
+
+public class SystemClock : ISystemClock
+{
+    public DateTime UtcNow => DateTime.UtcNow;
+
+    public DateTime Now => DateTime.Now;
+}

--- a/TimeKeeperApp/Services/TimeCheckLogger.cs
+++ b/TimeKeeperApp/Services/TimeCheckLogger.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TimeKeeperApp.Services;
+
+public class TimeCheckLogger : ITimeCheckLogger
+{
+    private const string LogsFolderName = "logs";
+    private const string FilePrefix = "timechecks-";
+    private const string FileExtension = ".log";
+
+    public Task LogAsync(DateTime timestamp, string server, double? offsetSeconds, string status, CancellationToken cancellationToken)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, LogsFolderName);
+        Directory.CreateDirectory(directory);
+
+        var fileName = $"{FilePrefix}{timestamp:yyyyMMdd}{FileExtension}";
+        var path = Path.Combine(directory, fileName);
+        var offsetText = offsetSeconds.HasValue ? offsetSeconds.Value.ToString("0.000000", CultureInfo.InvariantCulture) : string.Empty;
+        var line = $"{timestamp:O},{server},{offsetText},{status}{Environment.NewLine}";
+
+        return WriteAsync(path, line, cancellationToken);
+    }
+
+    private static async Task WriteAsync(string path, string content, CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read, 4096, true);
+        var bytes = Encoding.UTF8.GetBytes(content);
+        await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/TimeKeeperApp/TimeKeeperApp.Tests/MainViewModelTests.cs
+++ b/TimeKeeperApp/TimeKeeperApp.Tests/MainViewModelTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TimeKeeperApp.Models;
+using TimeKeeperApp.Services;
+using TimeKeeperApp.ViewModels;
+using Xunit;
+
+namespace TimeKeeperApp.Tests;
+
+public class MainViewModelTests
+{
+    [Fact]
+    public async Task PrimaryServerMustBeProvided()
+    {
+        var settings = new TimeCheckSettings
+        {
+            IntervalSeconds = 10,
+            Servers = new List<string> { string.Empty, string.Empty, string.Empty, string.Empty, string.Empty }
+        };
+
+        using var harness = CreateHarness(settings);
+        await harness.ViewModel.InitializeAsync();
+
+        Assert.Equal("Primary time server required.", harness.ViewModel.Servers[0].Error);
+        Assert.False(harness.ViewModel.CanStart);
+    }
+
+    [Fact]
+    public async Task IntervalValidationRequiresPositiveValue()
+    {
+        var settings = new TimeCheckSettings
+        {
+            IntervalSeconds = 5,
+            Servers = new List<string> { "time.test", string.Empty, string.Empty, string.Empty, string.Empty }
+        };
+
+        using var harness = CreateHarness(settings);
+        await harness.ViewModel.InitializeAsync();
+
+        harness.ViewModel.CheckIntervalSeconds = 0;
+
+        Assert.Equal("Interval must be 1 second or greater.", harness.ViewModel.IntervalError);
+        Assert.False(harness.ViewModel.CanStart);
+    }
+
+    [Fact]
+    public async Task EmptyServersAreSkipped()
+    {
+        var settings = new TimeCheckSettings
+        {
+            IntervalSeconds = 5,
+            Servers = new List<string> { "primary.test", string.Empty, "secondary.test", string.Empty, string.Empty }
+        };
+
+        using var harness = CreateHarness(settings);
+        await harness.ViewModel.InitializeAsync();
+
+        Assert.Equal(2, harness.ViewModel.ServerStatuses.Count);
+        Assert.All(harness.ViewModel.ServerStatuses, status => Assert.False(string.IsNullOrWhiteSpace(status.Server)));
+    }
+
+    [Fact]
+    public async Task OffsetCalculationUsesServerTimeDifference()
+    {
+        var settings = new TimeCheckSettings
+        {
+            IntervalSeconds = 5,
+            Servers = new List<string> { "primary.test", string.Empty, string.Empty, string.Empty, string.Empty }
+        };
+
+        var fakeClock = new FakeClock
+        {
+            Now = new DateTime(2024, 1, 1, 8, 0, 0),
+            UtcNow = new DateTime(2024, 1, 1, 13, 0, 0, DateTimeKind.Utc)
+        };
+
+        var ntpResponse = fakeClock.UtcNow.AddSeconds(1.234567);
+        var fakeClient = new FakeNtpClient(new Dictionary<string, DateTime>
+        {
+            ["primary.test"] = ntpResponse
+        });
+
+        using var harness = CreateHarness(settings, fakeClient, fakeClock);
+        await harness.ViewModel.InitializeAsync();
+
+        await harness.ViewModel.StartAsync();
+        harness.ViewModel.Stop();
+
+        var status = Assert.Single(harness.ViewModel.ServerStatuses);
+        Assert.Equal(1.234567, status.OffsetSeconds);
+        Assert.Equal("Success", status.StatusMessage);
+    }
+
+    private static ViewModelHarness CreateHarness(
+        TimeCheckSettings settings,
+        INtpClient? ntpClient = null,
+        ISystemClock? clock = null)
+    {
+        var fakeSettings = new FakeSettingsStore(settings);
+        var fakeLogger = new FakeLogger();
+        var syncContext = new TestSynchronizationContext();
+        var viewModel = new MainViewModel(
+            ntpClient ?? new FakeNtpClient(new Dictionary<string, DateTime>()),
+            fakeSettings,
+            fakeLogger,
+            clock ?? new FakeClock(),
+            syncContext);
+
+        return new ViewModelHarness(viewModel, fakeLogger);
+    }
+
+    private sealed class ViewModelHarness : IDisposable
+    {
+        public ViewModelHarness(MainViewModel viewModel, FakeLogger logger)
+        {
+            ViewModel = viewModel;
+            Logger = logger;
+        }
+
+        public MainViewModel ViewModel { get; }
+
+        public FakeLogger Logger { get; }
+
+        public void Dispose()
+        {
+            ViewModel.Dispose();
+        }
+    }
+
+    private sealed class FakeSettingsStore : ISettingsStore
+    {
+        private readonly TimeCheckSettings _settings;
+
+        public FakeSettingsStore(TimeCheckSettings settings)
+        {
+            _settings = new TimeCheckSettings
+            {
+                IntervalSeconds = settings.IntervalSeconds,
+                Servers = settings.Servers.ToList()
+            };
+        }
+
+        public TimeCheckSettings Load()
+        {
+            return new TimeCheckSettings
+            {
+                IntervalSeconds = _settings.IntervalSeconds,
+                Servers = _settings.Servers.ToList()
+            };
+        }
+
+        public void Save(TimeCheckSettings settings)
+        {
+            _settings.IntervalSeconds = settings.IntervalSeconds;
+            _settings.Servers = settings.Servers.ToList();
+        }
+    }
+
+    private sealed class FakeNtpClient : INtpClient
+    {
+        private readonly Dictionary<string, DateTime> _responses;
+
+        public FakeNtpClient(Dictionary<string, DateTime> responses)
+        {
+            _responses = responses;
+        }
+
+        public Task<NtpQueryResult> QueryAsync(string host, int timeoutMilliseconds, CancellationToken cancellationToken)
+        {
+            if (_responses.TryGetValue(host, out var response))
+            {
+                return Task.FromResult(new NtpQueryResult(response));
+            }
+
+            throw new NtpClientException($"No response configured for {host}.");
+        }
+    }
+
+    private sealed class FakeLogger : ITimeCheckLogger
+    {
+        public List<(DateTime Timestamp, string Server, double? Offset, string Status)> Entries { get; } = new();
+
+        public Task LogAsync(DateTime timestamp, string server, double? offsetSeconds, string status, CancellationToken cancellationToken)
+        {
+            Entries.Add((timestamp, server, offsetSeconds, status));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeClock : ISystemClock
+    {
+        public DateTime UtcNow { get; set; } = DateTime.UtcNow;
+
+        public DateTime Now { get; set; } = DateTime.Now;
+    }
+
+    private sealed class TestSynchronizationContext : SynchronizationContext
+    {
+        public override void Send(SendOrPostCallback d, object? state)
+        {
+            d(state);
+        }
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            d(state);
+        }
+    }
+}

--- a/TimeKeeperApp/TimeKeeperApp.Tests/NtpClientTests.cs
+++ b/TimeKeeperApp/TimeKeeperApp.Tests/NtpClientTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+using TimeKeeperApp.Services;
+using Xunit;
+
+namespace TimeKeeperApp.Tests;
+
+public class NtpClientTests
+{
+    [Fact]
+    public void ExtractNetworkTime_ReturnsExpectedUtcTime()
+    {
+        var expectedUtc = new DateTime(2024, 1, 15, 12, 34, 56, DateTimeKind.Utc).AddMilliseconds(789);
+        var ntpData = new byte[48];
+        WriteTimestamp(ntpData, expectedUtc);
+
+        var result = NtpClient.ExtractNetworkTime(ntpData);
+
+        Assert.Equal(expectedUtc, result);
+    }
+
+    private static void WriteTimestamp(byte[] buffer, DateTime timestampUtc)
+    {
+        var epoch = new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var seconds = (timestampUtc - epoch).TotalSeconds;
+        var intPart = (ulong)Math.Floor(seconds);
+        var fractionalSeconds = seconds - Math.Floor(seconds);
+        var fractPart = (ulong)Math.Round(fractionalSeconds * 0x100000000L);
+
+        var bytes = BitConverter.GetBytes(intPart).Reverse().ToArray();
+        Array.Copy(bytes, bytes.Length - 4, buffer, 40, 4);
+
+        bytes = BitConverter.GetBytes(fractPart).Reverse().ToArray();
+        Array.Copy(bytes, bytes.Length - 4, buffer, 44, 4);
+    }
+}

--- a/TimeKeeperApp/TimeKeeperApp.Tests/TimeKeeperApp.Tests.csproj
+++ b/TimeKeeperApp/TimeKeeperApp.Tests/TimeKeeperApp.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../TimeKeeperApp.csproj" />
+  </ItemGroup>
+</Project>

--- a/TimeKeeperApp/TimeKeeperApp.sln
+++ b/TimeKeeperApp/TimeKeeperApp.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimeKeeperApp", "TimeKeeperApp.csproj", "{EC43438E-181A-351E-5028-82AF5D0EEAE5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimeKeeperApp.Tests", "TimeKeeperApp.Tests\\TimeKeeperApp.Tests.csproj", "{B07DE9BB-AB9F-4CB4-B224-7BB90F71CBFA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -11,10 +13,14 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EC43438E-181A-351E-5028-82AF5D0EEAE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EC43438E-181A-351E-5028-82AF5D0EEAE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EC43438E-181A-351E-5028-82AF5D0EEAE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EC43438E-181A-351E-5028-82AF5D0EEAE5}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {EC43438E-181A-351E-5028-82AF5D0EEAE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {EC43438E-181A-351E-5028-82AF5D0EEAE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {EC43438E-181A-351E-5028-82AF5D0EEAE5}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B07DE9BB-AB9F-4CB4-B224-7BB90F71CBFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B07DE9BB-AB9F-4CB4-B224-7BB90F71CBFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B07DE9BB-AB9F-4CB4-B224-7BB90F71CBFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B07DE9BB-AB9F-4CB4-B224-7BB90F71CBFA}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/TimeKeeperApp/ViewModels/MainViewModel.cs
+++ b/TimeKeeperApp/ViewModels/MainViewModel.cs
@@ -1,0 +1,555 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using TimeKeeperApp.Models;
+using TimeKeeperApp.Services;
+
+namespace TimeKeeperApp.ViewModels;
+
+public class MainViewModel : INotifyPropertyChanged, IDisposable
+{
+    private const int MinimumIntervalSeconds = 1;
+    private const int DefaultTimeoutMilliseconds = 3000;
+    private static readonly Regex HostnamePattern = new("^[A-Za-z0-9.-]+$", RegexOptions.Compiled);
+
+    private readonly INtpClient _ntpClient;
+    private readonly ISettingsStore _settingsStore;
+    private readonly ITimeCheckLogger _logger;
+    private readonly ISystemClock _clock;
+    private readonly SynchronizationContext _uiContext;
+
+    private PeriodicTimer? _timer;
+    private CancellationTokenSource? _loopCancellation;
+    private bool _cycleInProgress;
+    private bool _disposed;
+    private bool _initializing;
+
+    private int _checkIntervalSeconds = 60;
+    private string? _intervalError;
+    private string? _globalStatusMessage;
+    private string? _globalWarningMessage;
+    private DateTime? _lastOverallCheckTime;
+    private bool _isRunning;
+
+    public MainViewModel()
+        : this(new NtpClient(), new SettingsStore(), new TimeCheckLogger(), new SystemClock(), SynchronizationContext.Current)
+    {
+    }
+
+    public MainViewModel(
+        INtpClient ntpClient,
+        ISettingsStore settingsStore,
+        ITimeCheckLogger logger,
+        ISystemClock clock,
+        SynchronizationContext? synchronizationContext)
+    {
+        _ntpClient = ntpClient;
+        _settingsStore = settingsStore;
+        _logger = logger;
+        _clock = clock;
+        _uiContext = synchronizationContext ?? new SynchronizationContext();
+
+        Servers = new ObservableCollection<ServerEntry>();
+        ServerStatuses = new ObservableCollection<ServerStatus>();
+
+        for (var i = 0; i < 5; i++)
+        {
+            var entry = new ServerEntry(i);
+            entry.PropertyChanged += OnServerEntryPropertyChanged;
+            Servers.Add(entry);
+        }
+    }
+
+    public ObservableCollection<ServerEntry> Servers { get; }
+
+    public ObservableCollection<ServerStatus> ServerStatuses { get; }
+
+    public int CheckIntervalSeconds
+    {
+        get => _checkIntervalSeconds;
+        set
+        {
+            if (_checkIntervalSeconds == value)
+            {
+                return;
+            }
+
+            _checkIntervalSeconds = value;
+            OnPropertyChanged();
+            ValidateInterval();
+            PersistSettings();
+            RestartTimerIfRunning();
+        }
+    }
+
+    public string? IntervalError
+    {
+        get => _intervalError;
+        private set
+        {
+            if (_intervalError == value)
+            {
+                return;
+            }
+
+            _intervalError = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HasValidationErrors));
+            OnPropertyChanged(nameof(CanStart));
+        }
+    }
+
+    public string? GlobalStatusMessage
+    {
+        get => _globalStatusMessage;
+        private set
+        {
+            if (_globalStatusMessage == value)
+            {
+                return;
+            }
+
+            _globalStatusMessage = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string? GlobalWarningMessage
+    {
+        get => _globalWarningMessage;
+        private set
+        {
+            if (_globalWarningMessage == value)
+            {
+                return;
+            }
+
+            _globalWarningMessage = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HasGlobalWarning));
+        }
+    }
+
+    public DateTime? LastOverallCheckTime
+    {
+        get => _lastOverallCheckTime;
+        private set
+        {
+            if (_lastOverallCheckTime == value)
+            {
+                return;
+            }
+
+            _lastOverallCheckTime = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsRunning
+    {
+        get => _isRunning;
+        private set
+        {
+            if (_isRunning == value)
+            {
+                return;
+            }
+
+            _isRunning = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool HasValidationErrors => Servers.Any(s => !string.IsNullOrWhiteSpace(s.Error)) || !string.IsNullOrWhiteSpace(IntervalError);
+
+    public bool CanStart => !HasValidationErrors;
+
+    public bool HasGlobalWarning => !string.IsNullOrEmpty(GlobalWarningMessage);
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public Task InitializeAsync()
+    {
+        _initializing = true;
+        try
+        {
+            var settings = _settingsStore.Load();
+            if (settings.Servers.Count < 5)
+            {
+                while (settings.Servers.Count < 5)
+                {
+                    settings.Servers.Add(string.Empty);
+                }
+            }
+
+            for (var i = 0; i < Servers.Count; i++)
+            {
+                Servers[i].Hostname = settings.Servers.ElementAtOrDefault(i) ?? string.Empty;
+            }
+
+            CheckIntervalSeconds = Math.Max(settings.IntervalSeconds, MinimumIntervalSeconds);
+            ValidateAllServers();
+            ValidateInterval();
+            UpdateServerStatuses();
+        }
+        finally
+        {
+            _initializing = false;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task StartAsync()
+    {
+        if (HasValidationErrors)
+        {
+            GlobalStatusMessage = "Cannot start checks until validation errors are resolved.";
+            return;
+        }
+
+        if (IsRunning)
+        {
+            return;
+        }
+
+        _loopCancellation = new CancellationTokenSource();
+        _timer = new PeriodicTimer(TimeSpan.FromSeconds(CheckIntervalSeconds));
+        RunOnUiThread(() =>
+        {
+            IsRunning = true;
+            GlobalStatusMessage = "Monitoring started.";
+        });
+
+        try
+        {
+            await PerformCheckCycleAsync(_loopCancellation.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Ignore cancellation during the initial run
+        }
+
+        _ = RunPeriodicChecksAsync(_loopCancellation.Token);
+    }
+
+    public void Stop()
+    {
+        _loopCancellation?.Cancel();
+        _loopCancellation?.Dispose();
+        _loopCancellation = null;
+
+        _timer?.Dispose();
+        _timer = null;
+
+        RunOnUiThread(() =>
+        {
+            if (IsRunning)
+            {
+                GlobalStatusMessage = "Monitoring stopped.";
+            }
+
+            IsRunning = false;
+        });
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        Stop();
+        foreach (var server in Servers)
+        {
+            server.PropertyChanged -= OnServerEntryPropertyChanged;
+        }
+        _disposed = true;
+    }
+
+    private async Task RunPeriodicChecksAsync(CancellationToken cancellationToken)
+    {
+        var timer = _timer;
+        if (timer is null)
+        {
+            return;
+        }
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (_cycleInProgress)
+                {
+                    continue;
+                }
+
+                await PerformCheckCycleAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when stopping
+        }
+        finally
+        {
+            timer.Dispose();
+            if (ReferenceEquals(_timer, timer))
+            {
+                _timer = null;
+            }
+
+            RunOnUiThread(() => IsRunning = false);
+        }
+    }
+
+    private async Task PerformCheckCycleAsync(CancellationToken cancellationToken)
+    {
+        if (_cycleInProgress)
+        {
+            return;
+        }
+
+        _cycleInProgress = true;
+        try
+        {
+            var activeServers = Servers.Where(s => !string.IsNullOrWhiteSpace(s.Hostname)).OrderBy(s => s.Index).ToList();
+            UpdateServerStatuses();
+
+            if (activeServers.Count == 0)
+            {
+                RunOnUiThread(() =>
+                {
+                    GlobalWarningMessage = "No servers configured.";
+                    GlobalStatusMessage = "Checks skipped.";
+                });
+                return;
+            }
+
+            var allFailed = true;
+
+            foreach (var entry in activeServers)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var status = GetStatusForSlot(entry.Index);
+                if (status is null)
+                {
+                    continue;
+                }
+
+                UpdateStatus(status, entry.Hostname, null, null, "Checking...", false);
+
+                try
+                {
+                    var result = await _ntpClient.QueryAsync(entry.Hostname, DefaultTimeoutMilliseconds, cancellationToken)
+                        .ConfigureAwait(false);
+                    var serverUtc = result.ServerTimeUtc;
+                    var systemUtc = _clock.UtcNow;
+                    var offset = Math.Round((serverUtc - systemUtc).TotalSeconds, 6);
+                    var now = _clock.Now;
+
+                    UpdateStatus(status, entry.Hostname, now, offset, "Success", false);
+                    await _logger.LogAsync(now, entry.Hostname, offset, "Success", cancellationToken).ConfigureAwait(false);
+                    allFailed = false;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    var now = _clock.Now;
+                    var message = $"Error: {ex.Message}";
+                    UpdateStatus(status, entry.Hostname, now, null, message, true);
+                    await _logger.LogAsync(now, entry.Hostname, null, message, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            var completedAt = _clock.Now;
+            RunOnUiThread(() =>
+            {
+                LastOverallCheckTime = completedAt;
+                GlobalStatusMessage = $"Last check completed at {completedAt:G}.";
+                GlobalWarningMessage = allFailed ? "All servers failed during the last cycle." : null;
+            });
+        }
+        finally
+        {
+            _cycleInProgress = false;
+        }
+    }
+
+    private void UpdateStatus(ServerStatus status, string server, DateTime? lastChecked, double? offsetSeconds, string message, bool hasError)
+    {
+        RunOnUiThread(() =>
+        {
+            status.Server = server;
+            status.LastChecked = lastChecked;
+            status.OffsetSeconds = offsetSeconds;
+            status.StatusMessage = message;
+            status.HasError = hasError;
+        });
+    }
+
+    private void OnServerEntryPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is not ServerEntry entry)
+        {
+            return;
+        }
+
+        if (e.PropertyName == nameof(ServerEntry.Hostname))
+        {
+            ValidateServerEntry(entry);
+            UpdateServerStatuses();
+            PersistSettings();
+            if (!_initializing && entry.Index == 0 && !string.IsNullOrWhiteSpace(entry.Error))
+            {
+                Stop();
+                RunOnUiThread(() => GlobalStatusMessage = "Primary time server required before monitoring can start.");
+            }
+        }
+    }
+
+    private void ValidateAllServers()
+    {
+        foreach (var server in Servers)
+        {
+            ValidateServerEntry(server);
+        }
+    }
+
+    private void ValidateServerEntry(ServerEntry entry)
+    {
+        if (entry.Index == 0 && string.IsNullOrWhiteSpace(entry.Hostname))
+        {
+            entry.Error = "Primary time server required.";
+        }
+        else if (string.IsNullOrWhiteSpace(entry.Hostname))
+        {
+            entry.Error = null;
+        }
+        else if (!HostnamePattern.IsMatch(entry.Hostname))
+        {
+            entry.Error = "Invalid hostname. Use letters, numbers, dots, and hyphens only.";
+        }
+        else
+        {
+            entry.Error = null;
+        }
+
+        OnPropertyChanged(nameof(HasValidationErrors));
+        OnPropertyChanged(nameof(CanStart));
+    }
+
+    private void ValidateInterval()
+    {
+        IntervalError = CheckIntervalSeconds < MinimumIntervalSeconds
+            ? "Interval must be 1 second or greater."
+            : null;
+    }
+
+    private void UpdateServerStatuses()
+    {
+        var current = ServerStatuses.ToDictionary(s => s.SlotIndex);
+        var updated = new List<ServerStatus>();
+
+        foreach (var entry in Servers.OrderBy(s => s.Index))
+        {
+            if (string.IsNullOrWhiteSpace(entry.Hostname))
+            {
+                continue;
+            }
+
+            if (current.TryGetValue(entry.Index, out var status))
+            {
+                if (!string.Equals(status.Server, entry.Hostname, StringComparison.OrdinalIgnoreCase))
+                {
+                    status.Server = entry.Hostname;
+                    status.LastChecked = null;
+                    status.OffsetSeconds = null;
+                    status.StatusMessage = "Not checked";
+                    status.HasError = false;
+                }
+
+                updated.Add(status);
+            }
+            else
+            {
+                updated.Add(new ServerStatus
+                {
+                    SlotIndex = entry.Index,
+                    Server = entry.Hostname,
+                    StatusMessage = "Not checked",
+                    HasError = false
+                });
+            }
+        }
+
+        RunOnUiThread(() =>
+        {
+            ServerStatuses.Clear();
+            foreach (var status in updated.OrderBy(s => s.SlotIndex))
+            {
+                ServerStatuses.Add(status);
+            }
+        });
+    }
+
+    private ServerStatus? GetStatusForSlot(int index)
+    {
+        return ServerStatuses.FirstOrDefault(s => s.SlotIndex == index);
+    }
+
+    private void PersistSettings()
+    {
+        if (_initializing || CheckIntervalSeconds < MinimumIntervalSeconds)
+        {
+            return;
+        }
+
+        var settings = new TimeCheckSettings
+        {
+            IntervalSeconds = CheckIntervalSeconds,
+            Servers = Servers.Select(s => s.Hostname).Take(5).ToList()
+        };
+
+        _settingsStore.Save(settings);
+    }
+
+    private void RestartTimerIfRunning()
+    {
+        if (!IsRunning || _timer is null || !string.IsNullOrWhiteSpace(IntervalError))
+        {
+            return;
+        }
+
+        Stop();
+        _ = StartAsync();
+    }
+
+    private void RunOnUiThread(Action action)
+    {
+        if (SynchronizationContext.Current == _uiContext)
+        {
+            action();
+        }
+        else
+        {
+            _uiContext.Send(_ => action(), null);
+        }
+    }
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,43 +1,45 @@
 # W32 Time Keeper
 
-W32 Time Keeper is a Windows desktop utility that monitors your system clock against a configurable list of network time servers and keeps it synchronized without relying on the built-in w32tm service. The application runs in the background, informs you when adjustments are made, and exposes a lightweight UI for manual syncs and configuration.
+W32 Time Keeper is a Windows desktop utility that monitors your system clock against a configurable list of network time servers and surfaces the live drift for each one. The application runs in the background, records offsets on a schedule you choose, and exposes a lightweight UI for managing servers and reviewing results.
 
 ## Features
 
-- **Background monitoring** – Periodically queries multiple NTP servers and adjusts the Windows system clock when drift exceeds your configured allowance.
-- **Manual sync** – Trigger an on-demand synchronization from the main window at any time.
-- **Start/Stop monitoring** – Use the toggle button to pause background checks or resume them as needed.
-- **Flexible server list** – Add or remove time servers directly from the UI; changes are persisted automatically.
-- **Tray integration** – Minimizes to the system tray with balloon notifications and restores on double-click.
-- **Configurable notifications** – Fine-tune notifications with separate controls for adjustment alerts and an overall mute.
-- **Windows auto-start** – Enable the app to launch automatically when Windows starts.
-- **Per-user settings** – All preferences are saved to the current user profile and applied at startup.
+- **Background monitoring** â€“ Periodically queries up to five user-provided NTP servers and reports their offsets without blocking the UI.
+- **Five configurable servers** â€“ The main window now exposes five labeled input slots where you can enter host names (e.g., `time.windows.com`). Empty secondary slots are ignored automatically.
+- **Configurable interval** â€“ Choose how often the check cycle runs by setting the "Check interval (seconds)" field directly in the main view.
+- **Status dashboard** â€“ See the most recent result for each server, including the timestamp, signed offset, and success/error state.
+- **Rolling log files** â€“ Every result is appended to `logs/timechecks-YYYYMMDD.log` alongside the UI updates for later review.
+- **Per-user settings** â€“ All preferences are saved to the current user profile and applied at startup.
 
 ## Configuration Options
 
-Open the **Settings** dialog to manage all configurable options:
+Use the main window to manage all configurable options:
 
-- **Drift allowance (ms):** Maximum drift tolerated before the clock is corrected.
-- **Check interval (s):** Frequency for background sync checks.
-- **Auto start with Windows:** Toggle to register/unregister the app as a startup program.
-- **Enable all notifications:** Master switch for tray notifications.
-- **Notify on time adjustment:** Optional alert shown only when the clock is adjusted.
-- **Time server list:** Manage servers from the main window using *Add* and *Remove Selected*.
+- **Server 1â€“5:** Enter host names (e.g., `time.windows.com`). Only populated entries are queried; Serverâ€¯1 is required.
+- **Check interval (seconds):** Frequency for background checks. Values below 1 second are rejected.
+- **Start/Stop buttons:** Control whether the scheduler is running.
 
 ## How It Works
 
-1. On launch, the app loads saved settings, starts the background monitor, and populates the server list.
-2. A timer triggers periodic checks; each check queries your servers (first successful response wins).
-3. When a valid network time is retrieved, the app compares it to the local clock. If the drift exceeds your allowance, it attempts to adjust the system time.
-4. Results (success, error, server used) are shown in the UI and optionally as tray notifications.
-5. You can manually toggle monitoring, run one-off syncs, or update settings at any time. Changes take effect immediately and are stored for future sessions.
+1. On launch, the app loads saved settings (see below), starts the background monitor, and populates the five server slots.
+2. A timer triggers periodic checks; each cycle queries the populated servers sequentially (Serverâ€¯1 â†’ Serverâ€¯5).
+3. The signed offset (server UTC minus system UTC) is calculated for each response and rounded to microseconds.
+4. Results (success or per-server error) are shown in the UI and written to the rolling log file.
+5. You can pause or resume monitoring with the buttons on the main window; updates take effect immediately and persist.
+
+## Configuration storage
+
+- **Settings file:** `%AppData%\W32TimeKeeper\settings.json`
+- **Log directory:** `logs\timechecks-YYYYMMDD.log` (relative to the application directory)
+
+The settings file stores the five server entries and the selected interval. It is updated automatically as fields change in the main window.
 
 ## Getting Started
 
 1. Build the solution with dotnet build (requires .NET 8.0 on Windows with WPF/WinForms support).
 2. Run the application (dotnet run or launch the generated executable).
-3. Configure your desired servers and thresholds via the **Settings** button.
-4. Leave the app running (minimized to tray) to keep your system clock aligned.
+3. Enter up to five time servers directly in the main window and set the desired interval.
+4. Leave the app running to monitor and log the offset for each configured server.
 
 ## Testing
 
@@ -47,4 +49,3 @@ Open the **Settings** dialog to manage all configurable options:
 ---
 
 Contributions and feedback are welcome! Submit issues or pull requests via GitHub to help improve W32 Time Keeper.
-


### PR DESCRIPTION
## Summary
- adjust the main toolbar layout to remove unsupported spacing attributes and show the last overall check text via inline runs
- tighten MainViewModel validation by updating CanStart when the interval changes, stopping with a clear message when Server 1 is cleared, skipping persistence for invalid intervals, and detaching handlers on dispose
- synchronize readme.md with the updated five-server monitoring workflow and storage details

## Testing
- Not run (dotnet CLI is not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68f694633e1c83329f935bbd13c63472